### PR TITLE
fix compiling with rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,3 +3,10 @@
 ]}.
 {edoc_opts, [{preprocess, true}, {macros, [{'EDOC', true}]}]}.
 {mib_first_files, ["mibs/SNMP-USER-BASED-SM-MIB.mib"]}.
+{plugins, [
+    {provider_asn1, ".*", {git, "https://github.com/knusbaum/provider_asn1.git", {tag, "0.2.3"}}}
+]}.
+{provider_hooks, [
+    {pre, [{compile, {asn, compile}}]},
+    {post, [{clean, {asn, clean}}]}
+]}.


### PR DESCRIPTION
To compile a project with modern rebar3, add plugin for compiling asn1 files. Because rebar3 can't compile asn1 files by default.